### PR TITLE
Upgrade mockito-core from 3.3.3 to 3.4.0

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -26,6 +26,6 @@ version.kotest=4.1.1
 
 version.kotlin=1.3.72
 
-version.org.mockito..mockito-core=3.3.3
+version.org.mockito..mockito-core=3.4.0
 
 version.io.github.classgraph..classgraph=4.8.87


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.