### PR TITLE
Upgrade detekt-formatting from 1.10.0 to 1.11.0-RC1

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -20,7 +20,7 @@ version.com.nhaarman.mockitokotlin2..mockito-kotlin=2.2.0
 
 version.com.uchuhimo..konf-yaml=0.22.1
 
-version.io.gitlab.arturbosch.detekt..detekt-formatting=1.10.0
+version.io.gitlab.arturbosch.detekt..detekt-formatting=1.11.0-RC1
 
 version.kotest=4.1.3
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.