### PR TITLE
Upgrade mockito-core from 3.5.0 to 3.5.2

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -26,6 +26,6 @@ version.kotest=4.1.3
 
 version.kotlin=1.3.72
 
-version.org.mockito..mockito-core=3.5.0
+version.org.mockito..mockito-core=3.5.2
 
 version.io.github.classgraph..classgraph=4.8.87


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.