### PR TITLE
Upgrade kotest from 4.1.3 to 4.2.0

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -22,7 +22,7 @@ version.com.uchuhimo..konf-yaml=0.22.1
 
 version.io.gitlab.arturbosch.detekt..detekt-formatting=1.11.1
 
-version.kotest=4.1.3
+version.kotest=4.2.0
 
 version.kotlin=1.3.72
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.