### PR TITLE
Upgrade mockito-core from 3.5.11 to 3.5.13

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -29,4 +29,4 @@ version.kotest=4.1.3
 
 version.kotlin=1.3.72
 
-version.org.mockito..mockito-core=3.5.11
+version.org.mockito..mockito-core=3.5.13


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.