### PR TITLE
Upgrade kotlin from 1.3.72 to 1.4.10

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -27,6 +27,6 @@ version.io.gitlab.arturbosch.detekt..detekt-formatting=1.14.2
 
 version.kotest=4.1.3
 
-version.kotlin=1.3.72
+version.kotlin=1.4.10
 
 version.org.mockito..mockito-core=3.5.15


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.