### PR TITLE
Upgrade kotest from 4.1.3 to 4.2.0

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -25,7 +25,7 @@ version.io.github.classgraph..classgraph=4.8.90
 
 version.io.gitlab.arturbosch.detekt..detekt-formatting=1.14.2
 
-version.kotest=4.1.3
+version.kotest=4.2.0
 
 version.kotlin=1.4.0
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.