### PR TITLE
Upgrade classgraph from 4.8.95 to 4.8.97

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -21,7 +21,7 @@ version..konf=0.22.1
 
 version.com.nhaarman.mockitokotlin2..mockito-kotlin=2.2.0
 
-version.io.github.classgraph..classgraph=4.8.95
+version.io.github.classgraph..classgraph=4.8.97
 
 version.io.gitlab.arturbosch.detekt..detekt-formatting=1.15.0
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.