### PR TITLE
Upgrade git-sensitive-semantic-versioning from 0.2.2 to 0.2.3

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -9,7 +9,7 @@ plugin.com.gradle.plugin-publish=0.12.0
 
 plugin.io.gitlab.arturbosch.detekt=1.15.0
 
-plugin.org.danilopianini.git-sensitive-semantic-versioning=0.2.2
+plugin.org.danilopianini.git-sensitive-semantic-versioning=0.2.3
 
 plugin.org.danilopianini.publish-on-central=0.4.1
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.