### PR TITLE
Upgrade mockito-core from 3.6.28 to 3.7.0

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -29,4 +29,4 @@ version.kotest=4.3.2
 
 version.kotlin=1.4.21
 
-version.org.mockito..mockito-core=3.6.28
+version.org.mockito..mockito-core=3.7.0


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.