### PR TITLE
Upgrade classgraph from 4.8.98 to 4.8.102

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -21,7 +21,7 @@ version..konf=1.0.0
 
 version.com.nhaarman.mockitokotlin2..mockito-kotlin=2.2.0
 
-version.io.github.classgraph..classgraph=4.8.98
+version.io.github.classgraph..classgraph=4.8.102
 
 version.io.gitlab.arturbosch.detekt..detekt-formatting=1.15.0
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.