### PR TITLE
Upgrade kotlin from 1.4.30 to 1.4.31

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -27,6 +27,6 @@ version.io.gitlab.arturbosch.detekt..detekt-formatting=1.15.0
 
 version.kotest=4.4.1
 
-version.kotlin=1.4.30
+version.kotlin=1.4.31
 
 version.org.mockito..mockito-core=3.7.7


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.