### PR TITLE
Upgrade kotest from 4.4.1 to 4.4.2

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -25,7 +25,7 @@ version.io.github.classgraph..classgraph=4.8.102
 
 version.io.gitlab.arturbosch.detekt..detekt-formatting=1.15.0
 
-version.kotest=4.4.1
+version.kotest=4.4.2
 
 version.kotlin=1.4.31
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.