### PR TITLE
Upgrade kotlin from 1.4.31 to 1.4.32

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -27,6 +27,6 @@ version.io.gitlab.arturbosch.detekt..detekt-formatting=1.16.0
 
 version.kotest=4.4.3
 
-version.kotlin=1.4.31
+version.kotlin=1.4.32
 
 version.org.mockito..mockito-core=3.8.0


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.