### PR TITLE
Upgrade dokka from 1.4.30 to 1.4.32

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -13,7 +13,7 @@ plugin.org.danilopianini.git-sensitive-semantic-versioning=0.2.3
 
 plugin.org.danilopianini.publish-on-central=0.4.3
 
-plugin.org.jetbrains.dokka=1.4.30
+plugin.org.jetbrains.dokka=1.4.32
 
 plugin.org.jlleitschuh.gradle.ktlint=10.0.0
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.