### PR TITLE
Upgrade kotest from 4.4.3 to 4.5.0

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -25,7 +25,7 @@ version.io.github.classgraph..classgraph=4.8.105
 
 version.io.gitlab.arturbosch.detekt..detekt-formatting=1.16.0
 
-version.kotest=4.4.3
+version.kotest=4.5.0
 
 version.kotlin=1.4.32
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.