### PR TITLE
Upgrade detekt-formatting from 1.16.0 to 1.17.0

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -23,7 +23,7 @@ version.com.nhaarman.mockitokotlin2..mockito-kotlin=2.2.0
 
 version.io.github.classgraph..classgraph=4.8.105
 
-version.io.gitlab.arturbosch.detekt..detekt-formatting=1.16.0
+version.io.gitlab.arturbosch.detekt..detekt-formatting=1.17.0
 
 version.kotest=4.5.0
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.