### PR TITLE
Upgrade kotlin from 1.4.32 to 1.5.10

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -29,7 +29,7 @@ version.io.gitlab.arturbosch.detekt..detekt-formatting=1.17.1
 
 version.kotest=4.6.1
 
-version.kotlin=1.4.32
+version.kotlin=1.5.10
 
 version.mockito=3.11.2
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.