### PR TITLE
Upgrade kotest from 4.6.0 to 4.6.1

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -27,7 +27,7 @@ version.io.github.classgraph..classgraph=4.8.110
 
 version.io.gitlab.arturbosch.detekt..detekt-formatting=1.17.1
 
-version.kotest=4.6.0
+version.kotest=4.6.1
 
 version.kotlin=1.4.32
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.