### PR TITLE
Upgrade git-sensitive-semantic-versioning from 0.2.3 to 0.3.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,10 +29,6 @@ inner class ProjectInfo {
 }
 val info = ProjectInfo()
 
-gitSemVer {
-    version = computeGitSemVer()
-}
-
 repositories {
     mavenCentral()
 }

--- a/versions.properties
+++ b/versions.properties
@@ -11,7 +11,7 @@ plugin.com.gradle.plugin-publish=0.15.0
 
 plugin.io.gitlab.arturbosch.detekt=1.17.1
 
-plugin.org.danilopianini.git-sensitive-semantic-versioning=0.2.3
+plugin.org.danilopianini.git-sensitive-semantic-versioning=0.3.0
 
 plugin.org.danilopianini.publish-on-central=0.5.0
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.